### PR TITLE
Performance improvements

### DIFF
--- a/cmac.go
+++ b/cmac.go
@@ -53,28 +53,24 @@ func gensubkeys(c cipher.Block) ([]byte, []byte) {
 }
 
 type cmac struct {
-	c  cipher.Block
-	k1 []byte
-	k2 []byte
-
-	x []byte
-
-	buf []byte
+	c           cipher.Block
+	k1, k2      []byte
+	buf, x, tmp []byte
 }
 
 func newcmac(c cipher.Block) *cmac {
 	k1, k2 := gensubkeys(c)
-	m := &cmac{c: c, k1: k1, k2: k2}
+	tmp := make([]byte, c.BlockSize())
+	m := &cmac{c: c, k1: k1, k2: k2, tmp: tmp}
 	m.Reset()
 	return m
 }
 
 func (m *cmac) block(b []byte) {
-	y := make([]byte, m.c.BlockSize())
-	for i := range y {
-		y[i] = m.x[i] ^ b[i]
+	for i := range m.tmp {
+		m.tmp[i] = m.x[i] ^ b[i]
 	}
-	m.c.Encrypt(m.x, y)
+	m.c.Encrypt(m.x, m.tmp)
 }
 
 func (m *cmac) Write(b []byte) (int, error) {

--- a/cmac.go
+++ b/cmac.go
@@ -60,8 +60,9 @@ type cmac struct {
 
 func newcmac(c cipher.Block) *cmac {
 	k1, k2 := gensubkeys(c)
+	x := make([]byte, c.BlockSize())
 	tmp := make([]byte, c.BlockSize())
-	m := &cmac{c: c, k1: k1, k2: k2, tmp: tmp}
+	m := &cmac{c: c, k1: k1, k2: k2, x: x, tmp: tmp}
 	m.Reset()
 	return m
 }
@@ -111,7 +112,9 @@ func (m *cmac) Sum(b []byte) []byte {
 
 func (m *cmac) Reset() {
 	m.buf = nil
-	m.x = make([]byte, m.c.BlockSize())
+	for i := range m.x {
+		m.x[i] = 0
+	}
 }
 
 func (m *cmac) Size() int {

--- a/cmac_test.go
+++ b/cmac_test.go
@@ -60,3 +60,19 @@ func TestNewWithCipher(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkHash1024(b *testing.B) {
+	buf := make([]byte, 1024)
+	h, _ := New(make([]byte, 128/8))
+	sum := make([]byte, 0, h.Size())
+
+	b.ReportAllocs()
+	b.SetBytes(1024)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h.Reset()
+		h.Write(buf)
+		h.Sum(sum)
+	}
+}


### PR DESCRIPTION
I took a profiler to this package and got a bunch of fun performance wins!

The net improvement from commits in this PR (as recorded on my early 2013 2.7 GHz Core i7 MacBook Pro) is as follows:

```
benchmark             old ns/op     new ns/op     delta
BenchmarkHash1024     11766         4608          -60.84%

benchmark             old MB/s     new MB/s     speedup
BenchmarkHash1024     87.03        222.21       2.55x

benchmark             old allocs     new allocs     delta
BenchmarkHash1024     66             0              -100.00%

benchmark             old bytes     new bytes     delta
BenchmarkHash1024     2064          0             -100.00%
```

The bulk of my effort was put into reducing allocations, so I'm sure I left some cycles on the table if you (or anyone else) is curious to hunt for them.
